### PR TITLE
pluralization update

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ urlpatterns = [
 
 The quickest way to get a working endpoint is to register a model with the router. Register accepts
 an optional keyword argument for the `url` associated to that endpoint. By default the url for an
-endpoint willbe `app_label/verbose_name_plural`
+endpoint willbe `app_label/model_name`
 
 ```python
 from drf_auto_endpoint.router import router


### PR DESCRIPTION
In commit 90f506a5b315944996f2f4b806b58ad1c444cf4b, there was a change in the name standardization of URLs and instead of using verbose_name_plural, the library uses model_name. This leads to some annoyances with multiple word models such as `EntityAttrbiute` having a URL of `entityattribute` instead of `entity_attribute`.

A PR could be done to use verbose_name_plural if it exists with a change to `_meta.verbose_name_plural.replace(" ","_").lower()`. The replacement would be required because `inflector` operates on the last word in the string and doesn't normalize the spaces.

```{python}
from inflector import Inflector
from django.utils.module_loading import import_string

inflector_language = import_string("inflector.English")
inflector = Inflector(inflector_language)
print(inflector.pluralize("Two Word").lower())
print(inflector.pluralize("Two_Word").lower())
```
```
two words
two_words
```
